### PR TITLE
[POC] Feature/issue 14 with-transaction macro

### DIFF
--- a/src/clj/gungnir/query.clj
+++ b/src/clj/gungnir/query.clj
@@ -86,7 +86,7 @@
   :args (s/alt
         :arity-1 (s/cat :changeset :gungnir/changeset)
         :arity-2 (s/cat :changeset :gungnir/changeset
-                        :datasource :sql/datasource))
+                        :datasource :sql/conn-or-datasource))
   :ret (s/or :changeset :gungnir/changeset
              :record map?))
 (defn save!


### PR DESCRIPTION
Just a POC, do not merge.

Here's a quick first pass at a `with-transaction` macro, based off the implementation from [conman](https://github.com/luminus-framework/conman).

The macro optionally accepts a defrefable, which is handy when the developer is using a system like `mount` to manage the gungnir ds state.

- [ ] Add multiple ds tests
- [ ] Write documentation

Because the fixtures clear the database after every `is`, I had to stuff everything into one `is` which is ugly but unavoidable unless the `each` fixtures are disabled.

`next.jdbc/with-transaction` returns a `HikariProxyConnection` object which implements the `java.sql.Connection` interface, hence the updates to the specs.