### PR TITLE
Only wrap SQLException's

### DIFF
--- a/src/clj/gungnir/database.clj
+++ b/src/clj/gungnir/database.clj
@@ -189,7 +189,7 @@
      (jdbc/execute-one! datasource (honey->sql form opts)
                         {:return-keys true
                          :builder-fn gungnir.database.builder/column-builder})
-     (catch Exception e
+     (catch SQLException e
        (println (honey->sql form))
        (update changeset :changeset/errors merge (exception->map e))))))
 


### PR DESCRIPTION
Allows non SQLException's to bubble up, as they cannot be marshaled
into user-friendly errors (by gungnir) and are likely indicative of
something that should be handled explicitly.

Fixes #19