### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,11 @@
+{:paths ["src/clj" "src/cljc" "resources"],
+ :deps
+ {com.github.seancorfield/next.jdbc {:mvn/version "1.3.847"},
+  org.postgresql/postgresql {:mvn/version "42.5.4"},
+  com.github.seancorfield/honeysql {:mvn/version "2.4.980"},
+  metosin/malli {:mvn/version "0.10.1"},
+  differ/differ {:mvn/version "0.3.3"},
+  hikari-cp/hikari-cp {:mvn/version "3.0.1"},
+  kwrooijen/clj-database-url {:mvn/version "0.0.1"},
+  org.clojure/tools.logging {:mvn/version "1.2.4"},
+  dev.weavejester/ragtime {:mvn/version "0.9.3"}}}


### PR DESCRIPTION
This library looks promising, thank you for sharing!

I've added a deps.edn created by [`lein2deps`](https://github.com/borkdude/lein2deps) [1]

The current main branch is not accessible as a dependency otherwise, also it is not recommended to use a snapshot release from maven.

My branch can be tested via [`deps-try`](https://github.com/eval/deps-try):

```
deps-try io.github.jeroenvandijk/gungnir "642426125ee4fcb7a3472ecc8c1e214be2ab78ef"
```

[1] `lein2deps --print --write-file deps.edn`

